### PR TITLE
Check if theres's a target before trying to actually poke at it

### DIFF
--- a/voltron/cmd.py
+++ b/voltron/cmd.py
@@ -77,6 +77,8 @@ class VoltronCommand (object):
             self.start_server()
         if self.helper == None:
             self.helper = self.find_helper()
+        if not self.has_target():
+            return
 
         # Process updates for registered clients
         log.debug("Processing updates")
@@ -105,6 +107,9 @@ class VoltronCommand (object):
 
     def find_helper(self):
         pass
+
+    def has_target(self):
+        return True
 
 
 class InheritorTracker (type):


### PR DESCRIPTION
Works around a bug in LLDB from Xcode5+ where it either:
- Tries to call the stop hook before the inferior has properly started
  OR
- Returns garbage when you ask for the inferiors registers due to some
  sweet race condition.

Either way, test first, and mock em out for gdb that evidently does the
right thing
