### PR TITLE
Create the socket in HOME

### DIFF
--- a/voltron/comms.py
+++ b/voltron/comms.py
@@ -13,7 +13,14 @@ from .common import *
 
 READ_MAX = 0xFFFF
 
-SOCK = "/tmp/voltron.sock"
+def _sock():
+    if "VOLTRON_SOCKET" in os.environ:
+        return os.getenv("VOLTRON_SOCKET")
+    else:
+        d = os.path.expanduser("~/.voltron")
+        if not os.path.exists(d):
+            os.mkdir(d, 0700)
+        return os.path.join(d, "voltron.sock")
 
 queue = Queue.Queue()
 clients = []
@@ -34,7 +41,7 @@ class Client (asyncore.dispatcher):
         success = False
         while not success:
             try:
-                self.connect(SOCK)
+                self.connect(_sock())
                 success = True
                 self.register()
             except Exception as e:
@@ -113,12 +120,12 @@ class ServerThread (threading.Thread):
     def run(self):
         # Make sure there's no left over socket
         try:
-            os.remove(SOCK)
+            os.remove(_sock())
         except:
             pass
 
         # Create a server socket instance
-        serv = ServerSocket(SOCK)
+        serv = ServerSocket(_sock())
         self.lock = threading.Lock()
         self.set_should_exit(False)
 
@@ -137,7 +144,7 @@ class ServerThread (threading.Thread):
             client.close()
         serv.close()
         try:
-            os.remove(SOCK)
+            os.remove(_sock())
         except:
             pass
 

--- a/voltron/gdbproxy.py
+++ b/voltron/gdbproxy.py
@@ -4,7 +4,7 @@ import socket
 import struct
 import cPickle as pickle
 
-from .comms import SOCK, READ_MAX
+from .comms import _sock, READ_MAX
 from .common import *
 
 log = configure_logging()
@@ -28,7 +28,7 @@ class GDB6Proxy (asyncore.dispatcher):
         if not args.debug:
             log.setLevel(logging.WARNING)
         self.create_socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.connect(SOCK)
+        self.connect(_sock())
 
     def run(self):
         asyncore.loop()


### PR DESCRIPTION
Support VOLTRON_SOCKET for running more than one voltron

Makes running more than one instance at a time feasible (it was doable before by constantly moving the socket about in /tmp and maintaining an elaborate web of symlinks). Now just set VOLTRON_SOCKET to something unique before you start tmux.

For bonus points this should create `~/.voltron/voltron.sock.$inferior_pid` when you start an inferior, but I couldn't find the magic to do it in the 4 minutes I looked.
