### PR TITLE
Use explicit string to convert Gdb.Value's

### DIFF
--- a/voltron/gdbcmd.py
+++ b/voltron/gdbcmd.py
@@ -134,7 +134,7 @@ class GDBHelperX86 (GDBHelper):
         for i in range(num):
             reg = 'xmm'+str(i)
             try:
-                regs[reg] = int(str(gdb.parse_and_eval('$'+reg+'.uint128')), 16) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                regs[reg] = int(gdb.parse_and_eval('$'+reg+'.uint128').string(), 16) & 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
             except:
                 log.debug('Failed getting reg: ' + reg)
                 regs[reg] = 'N/A'


### PR DESCRIPTION
If you really want to know what's going on (you probably don't), compare

valpy_str and valpy_string in gbd/python/py-value.c
