### PR TITLE
Start server when.. starting

### DIFF
--- a/voltron/cmd.py
+++ b/voltron/cmd.py
@@ -41,6 +41,7 @@ class VoltronCommand (object):
         if not self.running:
             print("Starting voltron")
             self.running = True
+            self.start_server()
             self.register_hooks()
         else:
             print("Already running")


### PR DESCRIPTION
Am I missing something really obvious here?

On ubuntu + gdb, without this the server thread never gets started so the views can't connect.
