### PR TITLE
Correctly extract arch on platforms where architecure().name() fails

### DIFF
--- a/voltron/gdbcmd.py
+++ b/voltron/gdbcmd.py
@@ -58,7 +58,7 @@ class GDBHelper (DebuggerHelper):
         try:
             return gdb.selected_frame().architecture().name()
         except:
-            return re.search('\(currently (.*)\)', gdb.execute('show architecture', to_string=True)).groups(0)
+            return re.search('\(currently (.*)\)', gdb.execute('show architecture', to_string=True)).group(1)
 
     @staticmethod
     def helper():


### PR DESCRIPTION
This fixes that bug I showed you last night. groups() returns tuples, group() returns the content of the matchgroup.

I've tested this exactly nowhere. It also doesn't fix that server not starting bug, but I have a workaround so I'm probably not going to look into it.

FWIW, I get:

```
(gdb) r
Starting program: /home/ubuntu/butts

Breakpoint 1, 0x0000000000400548 in main ()
(gdb) voltron start
Starting voltron
(gdb) voltron update
Python Exception <type 'exceptions.AttributeError'> 'NoneType' object has no attribute 'update_clients':
Error occurred in Python command: 'NoneType' object has no attribute 'update_clients'
(gdb)
```

So it definitely seems like the server object just never gets init'd.
