### PR TITLE
refresh helpers in interactive queries

### DIFF
--- a/voltron/comms.py
+++ b/voltron/comms.py
@@ -185,6 +185,10 @@ class Server (object):
     def handle_interactive_query(self, client, msg):
         log.debug('Got an interactive query from client {} of type {}'.format(self, msg['query']))
         resp = {'value': None}
+
+        # Make sure we have a helper
+        self.refresh_helper()
+
         if msg['query'] == 'get_register':
             reg = msg['register']
             registers = self.helper.get_registers()


### PR DESCRIPTION
fixes a crash when no views have been attached, and you try to use the
calculon integration
