### PR TITLE
python 3 compatibility

### DIFF
--- a/voltron/env.py
+++ b/voltron/env.py
@@ -9,7 +9,7 @@ ENV = Environment({
     'dir':  {
         'path': '~/.voltron',
         'create': True,
-        'mode': 0700
+        'mode': 448 # 0700
     },
     'files': {
         'config': {

--- a/voltron/lldbcmd.py
+++ b/voltron/lldbcmd.py
@@ -94,7 +94,7 @@ class LLDBHelper (DebuggerHelper):
                 except:
                     try:
                         val = int(reg.value)
-                    except Exception, e:
+                    except Exception as e:
                         log.debug("Exception converting register value: " + str(e))
                         val = 0
             regs[reg.name] = val

--- a/voltron/view.py
+++ b/voltron/view.py
@@ -121,7 +121,7 @@ class VoltronView (object):
         try:
             while True:
                 self.client.read()
-        except SocketDisconnected, e:
+        except SocketDisconnected as e:
             if self.should_reconnect():
                 log.debug("Restarting process: " + str(type(e)))
                 log.debug("Restarting process")


### PR DESCRIPTION
Had to futz with some things to make it work on recent gdb's that use python3

I think the `except Foo as bar` syntax works since python 2.6 or 2.7.. do you need to support anything before then?
