### PR TITLE
pythonic type coercion

### DIFF
--- a/voltron/core.py
+++ b/voltron/core.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import errno
 import logging
 import socket
@@ -18,6 +19,14 @@ from .api import *
 log = logging.getLogger("core")
 
 READ_MAX = 0xFFFF
+
+if sys.version_info.major == 2:
+    STRTYPES = (str, unicode)
+elif sys.version_info.major == 3:
+    STRTYPES = (str, bytes)
+else:
+    raise RuntimeError("Not sure what strings look like on python %d" %
+                       sys.version_info.major)
 
 class Server(object):
     """
@@ -239,7 +248,7 @@ class ServerThread(threading.Thread):
         log.debug("Exiting server thread")
 
     def cleanup_socket(self):
-        if type(self.sock) == str:
+        if isinstance(self.sock, STRTYPES):
             try:
                 os.remove(self.sock)
             except:
@@ -476,9 +485,9 @@ class ServerSocket(BaseSocket):
     Server socket for accepting new client connections.
     """
     def __init__(self, sock):
-        if type(sock) == str:
+        if isinstance(sock, STRTYPES):
             self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        elif type(sock) == tuple:
+        elif isinstance(sock, tuple):
             self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.sock.bind(sock)
         self.sock.listen(1)

--- a/voltron/plugins/view/register.py
+++ b/voltron/plugins/view/register.py
@@ -1,3 +1,5 @@
+from numbers import Number
+from voltron.core import STRTYPES
 from voltron.view import *
 from voltron.plugin import *
 from voltron.api import *
@@ -352,7 +354,7 @@ class RegisterView (TerminalView):
 
                     # Format the value
                     val = data[reg]
-                    if type(val) == str:
+                    if isinstance(val, STRTYPES):
                         temp = fmt['value_format'].format(0)
                         if len(val) < len(temp):
                             val += (len(temp) - len(val))*' '
@@ -362,10 +364,10 @@ class RegisterView (TerminalView):
                         if self.last_regs == None or self.last_regs != None and val != self.last_regs[reg]:
                             colour = fmt['value_colour_mod']
                         formatted_reg = val
-                        if fmt['value_format'] != None and type(formatted_reg) != str:
+                        if fmt['value_format'] != None and isinstance(formatted_reg, Number):
                             formatted_reg = fmt['value_format'].format(formatted_reg)
                         if fmt['value_func'] != None:
-                            if type(fmt['value_func']) == str:
+                            if isinstance(fmt['value_func'], STRTYPES):
                                 formatted_reg = eval(fmt['value_func'])(formatted_reg)
                             else:
                                 formatted_reg = fmt['value_func'](formatted_reg)


### PR DESCRIPTION
This fixes a bug initially triggered in my environment by getting u'n/a' back in DS. No idea why it is suddenly a `unicode`, but this is a bit more defensive regardless.