### PR TITLE
Fix re-running program in GDB

### DIFF
--- a/dbgentry.py
+++ b/dbgentry.py
@@ -206,9 +206,8 @@ try:
 
             def cont_handler(self, event):
                 log.debug('Inferior continued')
-                if self.server == None:
+                if self.server == None or self.server.is_running == False:
                     self.server = Server()
-                if self.server.is_running == False
                     self.server.start()
 
 

--- a/dbgentry.py
+++ b/dbgentry.py
@@ -208,6 +208,7 @@ try:
                 log.debug('Inferior continued')
                 if self.server == None:
                     self.server = Server()
+                if self.server.is_running == False
                     self.server.start()
 
 

--- a/voltron/core.py
+++ b/voltron/core.py
@@ -45,6 +45,8 @@ class Server(object):
         self.d_exit_out, self.d_exit_in = os.pipe()
         self.t_exit_out, self.t_exit_in = os.pipe()
 
+        self.is_running = False
+
     def start(self):
         listen = voltron.config['server']['listen']
         if listen['domain']:
@@ -61,6 +63,7 @@ class Server(object):
             voltron.http.app.server = self
             self.h_thread = HTTPServerThread(self, self.clients, host, port)
             self.h_thread.start()
+        self.is_running = True
 
     def stop(self):
         # terminate the server thread by writing some data to the exit pipe
@@ -76,6 +79,7 @@ class Server(object):
         if self.h_thread:
             log.debug("Stopping HTTP server")
             self.h_thread.stop()
+        self.is_running = False
         log.debug("Finished stopping server threads")
 
     def client_summary(self):


### PR DESCRIPTION
Progame can't run again correctly for setting stop_and_exit_handler as gdb exit event handler

To fix it:
1. Add is_running to Class Server to indicate if a server is running
2. Modify cont_handler to create a new server if server is None or not running