### PR TITLE
Enable loading of API plugins without loading the other plugins.

### DIFF
--- a/dbgentry.py
+++ b/dbgentry.py
@@ -3,7 +3,7 @@ try:
     blessed = None
     import blessed
 
-    import voltron
+    import voltron.full
     from voltron.core import Server
     from voltron.plugin import PluginManager
     try:

--- a/voltron/__init__.py
+++ b/voltron/__init__.py
@@ -3,7 +3,6 @@ import logging
 import logging.config
 
 import voltron
-from .main import main
 
 from scruffy import Environment, Directory, File, ConfigFile, PluginDirectory, PackageDirectory
 
@@ -19,16 +18,21 @@ commands = None
 
 loaded = False
 
-def setup_env():
+def setup_env(api_only=False):
     global env, config
+    plugin_directory = 'plugins'
+
+    if api_only:
+        plugin_directory = os.path.join(plugin_directory, 'api')
+
     env = Environment(setup_logging=False,
         voltron_dir=Directory('~/.voltron', create=True,
             config=ConfigFile('config', defaults=File('config/default.cfg', parent=PackageDirectory())),
             sock=File('sock'),
             history=File('history'),
-            user_plugins=PluginDirectory('plugins')
+            user_plugins=PluginDirectory(plugin_directory)
         ),
-        pkg_plugins=PluginDirectory('plugins', parent=PackageDirectory())
+        pkg_plugins=PluginDirectory(plugin_directory, parent=PackageDirectory())
     )
     config = env.config
 
@@ -89,5 +93,5 @@ def setup_logging(logname=None):
 if not hasattr(__builtins__, "xrange"):
     xrange = range
 
-# Setup the Voltron environment
-setup_env()
+# Setup the Voltron environment to load only API plugins.
+setup_env(api_only=True)

--- a/voltron/__main__.py
+++ b/voltron/__main__.py
@@ -1,3 +1,5 @@
+# Make sure all plugins are initialized
+from . import full
 from .main import main
 
 main()

--- a/voltron/full.py
+++ b/voltron/full.py
@@ -1,0 +1,3 @@
+from . import setup_env
+
+setup_env()


### PR DESCRIPTION
This is crucial to running a Voltron client on Windows, as the `view` plugins require `curses`, which does not exist for Windows.

This change requires very little modification in code already using Voltron. By changing `import voltron` to `import voltron.full`
all the code will work as usual. When importing from Voltron (`from voltron import ...`), make sure to `import voltron.full` first.