### PR TITLE
repr errors before creating APIGenericErrorResponse's

### DIFF
--- a/examples/angularview/angularview.py
+++ b/examples/angularview/angularview.py
@@ -21,7 +21,7 @@ class FormatDisassemblyRequest(APIRequest):
             res = FormatDisassemblyResponse(
                 disassembly=pygments.highlight(self.disassembly.strip(), LLDBIntelLexer(), pygments.formatters.HtmlFormatter()))
         except Exception as e:
-            msg = "Exception formatting disassembly: {}".format(e)
+            msg = "Exception formatting disassembly: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/core.py
+++ b/voltron/core.py
@@ -250,7 +250,7 @@ class Server(object):
             try:
                 res = req.dispatch()
             except Exception as e:
-                msg = "Exception raised while dispatching request: {}".format(e)
+                msg = "Exception raised while dispatching request: {}".format(repr(e))
                 log.exception(msg)
                 res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/breakpoints.py
+++ b/voltron/plugins/api/breakpoints.py
@@ -29,7 +29,7 @@ class APIBreakpointsRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception getting breakpoints: {}".format(e)
+            msg = "Exception getting breakpoints: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/command.py
+++ b/voltron/plugins/api/command.py
@@ -30,7 +30,7 @@ class APICommandRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception executing debugger command: {}".format(e)
+            msg = "Exception executing debugger command: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/dereference.py
+++ b/voltron/plugins/api/dereference.py
@@ -31,7 +31,7 @@ class APIDerefRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception dereferencing pointer: {}".format(e)
+            msg = "Exception dereferencing pointer: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/memory.py
+++ b/voltron/plugins/api/memory.py
@@ -104,7 +104,7 @@ class APIMemoryRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception getting memory from debugger: {}".format(e)
+            msg = "Exception getting memory from debugger: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/registers.py
+++ b/voltron/plugins/api/registers.py
@@ -43,7 +43,7 @@ class APIRegistersRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception getting registers from debugger: {}".format(e)
+            msg = "Exception getting registers from debugger: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 

--- a/voltron/plugins/api/targets.py
+++ b/voltron/plugins/api/targets.py
@@ -26,7 +26,7 @@ class APITargetsRequest(APIRequest):
         except NoSuchTargetException:
             res = APINoSuchTargetErrorResponse()
         except Exception as e:
-            msg = "Exception getting targets from debugger: {}".format(e)
+            msg = "Exception getting targets from debugger: {}".format(repr(e))
             log.exception(msg)
             res = APIGenericErrorResponse(msg)
 


### PR DESCRIPTION
Many of the errors that Voltron encounters __str__ into an empty string,
but __repr__ into a useful string describing the error.