### PR TITLE
Remove pip user mode when installing in a venv

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,7 @@ while getopts ":dsSb:v:" opt; do
       ;;
     v)
       VENV="${OPTARG}"
+      USER_MODE=''
       SUDO=''
       ;;
     S)


### PR DESCRIPTION
`--user` will fail inside a virtualenv with the following message:

```
+ /Users/xxx/venv/voltron/bin/python -m pip install -U --user .
Can not perform a '--user' install. User site-packages are not visible in this virtualenv.
```

Afaict this doesn't break anything else, and respects the intentions of the user and installer. Tested on macOS 10.12.