### PR TITLE
Renaming the async variable

### DIFF
--- a/voltron/plugins/view/memory.py
+++ b/voltron/plugins/view/memory.py
@@ -13,7 +13,7 @@ log = logging.getLogger("view")
 class MemoryView(TerminalView):
     printable_filter = ''.join([(len(repr(chr(x))) == 3) and chr(x) or '.' for x in range(256)])
 
-    async = True
+    asynchronous = True
     last_memory = None
     last_address = 0
 


### PR DESCRIPTION
Renaming the async variable because it is a keyword in new python versions and this breaks voltron.

Fixing Issue #241