### PR TITLE
Fixed install script for lldb 8

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -164,8 +164,8 @@ fi
 
 if [ "${BACKEND_LLDB}" -eq 1 ]; then
     # Find the Python version used by LLDB
-    LLDB_PYVER=$(${LLDB} -Qxb --one-line 'script import platform; print(".".join(platform.python_version_tuple()[:2]))'|tail -1)
-    LLDB_PYTHON=$(${LLDB} -Qxb --one-line 'script import sys; print(sys.executable)'|tail -1)
+    LLDB_PYVER=$(${LLDB} -Q -x -b --one-line 'script import platform; print(".".join(platform.python_version_tuple()[:2]))'|tail -1)
+    LLDB_PYTHON=$(${LLDB} -Q -x -b --one-line 'script import sys; print(sys.executable)'|tail -1)
     LLDB_PYTHON="${LLDB_PYTHON/%$LLDB_PYVER/}${LLDB_PYVER}"
 
     ${LLDB_PYTHON} -m pip install --user --upgrade six    
@@ -177,9 +177,9 @@ if [ "${BACKEND_LLDB}" -eq 1 ]; then
         LLDB_PYTHON="${VENV}/bin/python"
         LLDB_SITE_PACKAGES=$(find "${VENV}" -name site-packages)
     elif [ -z "${USER_MODE}" ]; then
-        LLDB_SITE_PACKAGES=$(${LLDB} -Qxb --one-line 'script import site; print(site.getsitepackages()[0])'|tail -1)
+        LLDB_SITE_PACKAGES=$(${LLDB} -Q -x -b --one-line 'script import site; print(site.getsitepackages()[0])'|tail -1)
     else
-        LLDB_SITE_PACKAGES=$(${LLDB} -Qxb --one-line 'script import site; print(site.getusersitepackages())'|tail -1)
+        LLDB_SITE_PACKAGES=$(${LLDB} -Q -x -b --one-line 'script import site; print(site.getusersitepackages())'|tail -1)
     fi
 
     install_packages


### PR DESCRIPTION
When I try to use the `install.sh` with my lldb 8.0.0 installation on arch linux, it fails with the following error:

```
┌─┄ daniel@beta ┄┄┄ ~/proj/Python/voltron/ ┄┄┄ master
╰ $ ./install.sh -b lldb
+ '[' 0 -eq 1 ']'
+ '[' 1 -eq 1 ']'
++ /usr/bin/lldb -Qxb --one-line 'script import platform; print(".".join(platform.python_version_tuple()[:2]))'
++ tail -1
warning: ignoring unknown option: -Qxb
```

If I try the command with lldb 7 on ubuntu 19.04, it seems to work

```
root@b1eae42f03b3:/# lldb-7 -Qxb   
root@b1eae42f03b3:/#
```

A test with lldb 8.0.0 on ubuntu 19.04 reveals, that the "short" syntax of the flag seems to be removed from lldb 8 (even if I'm not able to find it in the changelogs).

```
root@b1eae42f03b3:/# lldb-8 -Qxb
warning: ignoring unknown option: -Qxb
(lldb) ^D
root@b1eae42f03b3:/# lldb-8 -Q -x -b
root@b1eae42f03b3:/#
```

----

This pull request aims to fix the above described issue with the separation of the commandline parameters in the lldb setup function.