### PR TITLE
Change 'async' mode to '_async'

### DIFF
--- a/voltron/core.py
+++ b/voltron/core.py
@@ -543,8 +543,8 @@ class Client(object):
                 if not self.server_version:
                     self.server_version = self.perform_request('version')
 
-                    # if the server supports async mode, use it, as some views may only work in async mode
-                    if self.server_version.capabilities and 'async' in self.server_version.capabilities:
+                    # if the server supports _async mode, use it, as some views may only work in async mode
+                    if self.server_version.capabilities and '_async' in self.server_version.capabilities:
                         self.update()
                         self.block = False
                     elif self.supports_blocking:
@@ -556,7 +556,7 @@ class Client(object):
                     # synchronous requests
                     self.update()
                 else:
-                    # async requests, block using a null request until the debugger stops again
+                    # _async requests, block using a null request until the debugger stops again
                     res = self.perform_request('null', block=True)
                     if res.is_success:
                         self.server_version = res

--- a/voltron/dbg.py
+++ b/voltron/dbg.py
@@ -187,7 +187,7 @@ class DebuggerAdaptor(object):
         """
         Return a list of the debugger's capabilities.
 
-        Thus far only the 'async' capability is supported. This indicates
+        Thus far only the '_async' capability is supported. This indicates
         that the debugger host can be queried from a background thread,
         and that views can use non-blocking API requests without queueing
         requests to be dispatched next time the debugger stops.

--- a/voltron/plugins/api/version.py
+++ b/voltron/plugins/api/version.py
@@ -33,7 +33,7 @@ class APIVersionResponse(APISuccessResponse):
         "data": {
             "api_version":  1.0,
             "host_version": 'lldb-something',
-            "capabilities": ["async"]
+            "capabilities": ["_async"]
         }
     }
     """

--- a/voltron/plugins/debugger/dbg_gdb.py
+++ b/voltron/plugins/debugger/dbg_gdb.py
@@ -460,12 +460,12 @@ if HAVE_GDB:
             """
             Return a list of the debugger's capabilities.
 
-            Thus far only the 'async' capability is supported. This indicates
+            Thus far only the '_async' capability is supported. This indicates
             that the debugger host can be queried from a background thread,
             and that views can use non-blocking API requests without queueing
             requests to be dispatched next time the debugger stops.
             """
-            return ['async']
+            return ['_async']
 
         #
         # Private functions

--- a/voltron/plugins/debugger/dbg_lldb.py
+++ b/voltron/plugins/debugger/dbg_lldb.py
@@ -37,7 +37,7 @@ if HAVE_LLDB:
             else:
                 log.debug("No debugger host found - creating one")
                 self.host = lldb.SBDebugger.Create()
-                self.host.SetAsync(False)
+                self.host.Setasync(False)
 
         @property
         def host(self):
@@ -503,12 +503,12 @@ if HAVE_LLDB:
             """
             Return a list of the debugger's capabilities.
 
-            Thus far only the 'async' capability is supported. This indicates
+            Thus far only the '_async' capability is supported. This indicates
             that the debugger host can be queried from a background thread,
             and that views can use non-blocking API requests without queueing
             requests to be dispatched next time the debugger stops.
             """
-            return ["async"]
+            return ["_async"]
 
         def register_command_plugin(self, name, cls):
             """

--- a/voltron/plugins/debugger/dbg_vdb.py
+++ b/voltron/plugins/debugger/dbg_vdb.py
@@ -408,12 +408,12 @@ if HAVE_VDB:
             """
             Return a list of the debugger's capabilities.
 
-            Thus far only the 'async' capability is supported. This indicates
+            Thus far only the '_async' capability is supported. This indicates
             that the debugger host can be queried from a background thread,
             and that views can use non-blocking API requests without queueing
             requests to be dispatched next time the debugger stops.
             """
-            return ['async']
+            return ['_async']
 
         #
         # Private functions

--- a/voltron/plugins/debugger/dbg_windbg.py
+++ b/voltron/plugins/debugger/dbg_windbg.py
@@ -393,12 +393,12 @@ if in_windbg:
             """
             Return a list of the debugger's capabilities.
 
-            Thus far only the 'async' capability is supported. This indicates
+            Thus far only the '_async' capability is supported. This indicates
             that the debugger host can be queried from a background thread,
             and that views can use non-blocking API requests without queueing
             requests to be dispatched next time the debugger stops.
             """
-            return ['async']
+            return ['_async']
 
         #
         # Private functions

--- a/voltron/plugins/view/memory.py
+++ b/voltron/plugins/view/memory.py
@@ -13,7 +13,7 @@ log = logging.getLogger("view")
 class MemoryView(TerminalView):
     printable_filter = ''.join([(len(repr(chr(x))) == 3) and chr(x) or '.' for x in range(256)])
 
-    async = True
+    _async = True
     last_memory = None
     last_address = 0
 


### PR DESCRIPTION
Needed to fix new reserved keywords in Python3.7+.
https://docs.python.org/3/whatsnew/3.7.html