### PR TITLE
Fix lldb 1100.0.28.19

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -197,9 +197,9 @@ if [ "${BACKEND_LLDB}" -eq 1 ]; then
         LLDB_PYTHON="${VENV}/bin/python"
         LLDB_SITE_PACKAGES=$(find "${VENV}" -name site-packages)
     elif [ -z "${USER_MODE}" ]; then
-        LLDB_SITE_PACKAGES=$(${LLDB} -Qxb --one-line 'script import site; print(site.getsitepackages()[0])'|tail -1)
+        LLDB_SITE_PACKAGES=$(${LLDB} -Q -x -b --one-line 'script import site; print(site.getsitepackages()[0])'|tail -1)
     else
-        LLDB_SITE_PACKAGES=$(${LLDB} -Qxb --one-line 'script import site; print(site.getusersitepackages())'|tail -1)
+        LLDB_SITE_PACKAGES=$(${LLDB} -Q -x -b --one-line 'script import site; print(site.getusersitepackages())'|tail -1)
     fi
 
     install_packages

--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,15 @@ if [ "${BACKEND_LLDB}" -eq 1 ] && [ -z "${LLDB}" ]; then
     exit 1
 fi
 
+function quit {
+    if [ $# -gt 1 ];
+    then
+        echo "$1"
+        shift
+    fi
+    exit $1
+}
+
 set -ex
 
 function install_apt {

--- a/install.sh
+++ b/install.sh
@@ -186,11 +186,8 @@ if [ "${BACKEND_GDB}" -eq 1 ]; then
 fi
 
 if [ "${BACKEND_LLDB}" -eq 1 ]; then
-    # Find the Python version used by LLDB
-    LLDB_PYVER=$(${LLDB} -Qxb --one-line 'script import platform; print(".".join(platform.python_version_tuple()[:2]))'|tail -1)
-    LLDB_PYTHON=$(${LLDB} -Qxb --one-line 'script import sys; print(sys.executable)'|tail -1)
-    LLDB_PYTHON="${LLDB_PYTHON/%$LLDB_PYVER/}${LLDB_PYVER}"
 
+    LLDB_PYTHON=$(get_lldb_python_exe)
     ${LLDB_PYTHON} -m pip install --user --upgrade six    
 
     if [ -n "${VENV}" ]; then


### PR DESCRIPTION
Fix configuration for lldb that ships with newer Xcode's in the following ways:

- Fix `lldb` incantation to split of the -Q -x -b args because the llvm project thought it was really important to break that behavior (this should work on older lldb versions)
- lldb no longer reports python as sys.executable, so we cobble together the best python interpreter from `sys.exec_prefix+"/bin/python”`
- I wasn't able to test on older systems (Sierra) because it doesn't have pip, and you can't easy_install pip due to TLS deprecation, so we `curl` the pip bootstrap script from bootstrap.pypa.io and run that
- The bootstrap script is then somehow able to install pip and dependencies and update our TLS