### PR TITLE
fix xrange in voltron.plugin.api

### DIFF
--- a/voltron/plugins/api/__init__.py
+++ b/voltron/plugins/api/__init__.py
@@ -1,0 +1,2 @@
+if not hasattr(__builtins__, "xrange"):
+    xrange = range


### PR DESCRIPTION
For some reason `voltron.plugin.api` wasn't picking up the `xrange = range` done in `voltron/__init__.py`, so let's add that to `voltron/plugin/api/__init__.py`