### PR TITLE
more xrange fixes

### DIFF
--- a/voltron/plugins/__init__.py
+++ b/voltron/plugins/__init__.py
@@ -1,0 +1,2 @@
+if not hasattr(__builtins__, "xrange"):
+    xrange = range

--- a/voltron/plugins/debugger/__init__.py
+++ b/voltron/plugins/debugger/__init__.py
@@ -1,0 +1,2 @@
+if not hasattr(__builtins__, "xrange"):
+    xrange = range

--- a/voltron/plugins/debugger/dbg_lldb.py
+++ b/voltron/plugins/debugger/dbg_lldb.py
@@ -10,6 +10,8 @@ from voltron.api import *
 from voltron.plugin import *
 from voltron.dbg import *
 
+from voltron.plugins.debugger import xrange
+
 try:
     import lldb
     HAVE_LLDB = True


### PR DESCRIPTION
packages don't know their parent package, so we have to explicitly set the xrange alias in more places