### PR TITLE
fix KEY ERROR of GDB debugger's target arch

### DIFF
--- a/voltron/plugins/debugger/dbg_gdb.py
+++ b/voltron/plugins/debugger/dbg_gdb.py
@@ -649,6 +649,14 @@ if HAVE_GDB:
                 arch = gdb.selected_frame().architecture().name()
             except:
                 arch = re.search('\(currently (.*)\)', gdb.execute('show architecture', to_string=True)).group(1)
+            
+            # Fix bug:
+            #       Exception getting targets from debugger: KeyError('"i386"')    
+            #         gdb: 10.2      python: 3.9.2      kali-linux(WSL2)
+            quot = ['\'','"']   
+            if len(arch) > 2 and arch[0] in quot and arch[-1] in quot:
+                arch = arch.split(quot[quot.index(arch[0])])[1]
+                
             return self.archs[arch]
 
         def get_addr_size(self):


### PR DESCRIPTION
> WSL2: kali-linux
>
> gdb: 10.2
>
> python: 3.9.2
>
> voltron successfully loaded

however when I run `voltron v r`, I got an exception: 

```
                                                             [regs:general]
Exception getting targets from debugger: KeyError('"i386"')
```

 `main.log` :

```
2021-09-02 16:24:50,389 DEBUG        view.py:165              __init__ -- Loading view: RegisterView
2021-09-02 16:24:50,389 DEBUG        view.py:180              __init__ -- View config: {'clear': True, 'update_on': 'stop', 'format': {'pygments_style': 'volarized', 'pygments_formatter': 'terminal256', 'label_format': '{0}', 'label_func': 'str_upper', 'label_colour': 'green', 'label_colour_en': True, 'value_format': '{0:0=16X}', 'value_func': None, 'value_colour': 'reset', 'value_colour_mod': 'red', 'value_colour_en': True, 'format_name': None, 'addr_colour': 'blue', 'divider_colour': 'green', 'string_colour': 'white', 'symbol_colour': 'cyan'}, 'header': {'show': True, 'pad': ' ', 'colour': 'blue', 'bg_colour': 'grey', 'attrs': [], 'label_left': {'name': 'info', 'colour': 'blue', 'bg_colour': 'grey', 'attrs': []}, 'label_right': {'name': 'title', 'colour': 'white', 'bg_colour': 'grey', 'attrs': ['bold']}}, 'footer': {'show': False, 'pad': ' ', 'colour': 'blue', 'bg_colour': 'grey', 'attrs': [], 'label_left': {'name': None, 'colour': 'blue', 'bg_colour': 'grey', 'attrs': []}, 'label_right': {'name': None, 'colour': 'blue', 'bg_colour': 'grey', 'attrs': ['bold']}}, 'pad': {'pad_right': 0, 'pad_bottom': 0}, 'keymap': {'q': 'exit', 'p': 'page_up', 'n': 'page_down', 'KEY_PPAGE': 'page_up', 'KEY_NPAGE': 'page_down', 'KEY_UP': 'line_up', 'KEY_DOWN': 'line_down', 'KEY_ENTER': 'reset'}, 'type': 'register', 'sections': ['general'], 'orientation': 'vertical'}
2021-09-02 16:24:50,389 DEBUG        view.py:181              __init__ -- Args: Namespace(debug=False, o=[], subcommand='view', view='register', header=None, footer=None, name=None, orientation=None, sections=None, hide_info=False, func=<class 'register.RegisterView'>)
2021-09-02 16:24:50,389 DEBUG        view.py:222                 setup -- Base view class setup
2021-09-02 16:24:50,389 DEBUG        core.py:432          send_request -- Client sending request: {"type": "request", "request": "version", "block": false, "timeout": 10, "data": {}}
2021-09-02 16:24:50,393 DEBUG        core.py:438          send_request -- Client received message: {"type": "response", "status": "success", "data": {"api_version": 1.1, "host_version": "GNU gdb (GDB) 10.2", "capabilities": ["async"]}}
2021-09-02 16:24:50,393 DEBUG        core.py:432          send_request -- Client sending request: {"type": "request", "request": "targets", "block": false, "timeout": 10, "data": {}}
2021-09-02 16:24:50,393 DEBUG        core.py:432          send_request -- Client sending request: {"type": "request", "request": "disassemble", "block": false, "timeout": 10, "data": {"target_id": 0, "address": null, "count": 1, "use_capstone": null}}
2021-09-02 16:24:50,394 DEBUG        core.py:432          send_request -- Client sending request: {"type": "request", "request": "registers", "block": false, "timeout": 10, "data": {"target_id": 0, "thread_id": null, "registers": []}}
2021-09-02 16:24:50,396 DEBUG        core.py:438          send_request -- Client received message: {"type": "response", "status": "error", "data": {"code": 4096, "message": "Exception getting targets from debugger: KeyError('\"i386\"')"}}
2021-09-02 16:24:50,398 DEBUG        core.py:438          send_request -- Client received message: {"type": "response", "status": "error", "data": {"code": 4101, "message": "No such target"}}
2021-09-02 16:24:50,398 DEBUG        core.py:438          send_request -- Client received message: {"type": "response", "status": "error", "data": {"code": 4101, "message": "No such target"}}
2021-09-02 16:24:50,432 DEBUG        core.py:432          send_request -- Client sending request: {"type": "request", "request": "null", "block": true, "timeout": 10, "data": {}}
2021-09-02 16:24:51,767 DEBUG        view.py:262               cleanup -- Cleaning up view
```

while reading the source code, I found out the problem probably lies in the function `get_arch(self)` in `plugins/debugger/dbg_gdb.py`

```python
        def get_arch(self):
            try:
                arch = gdb.selected_frame().architecture().name()
            except:
                arch = re.search('\(currently (.*)\)', gdb.execute('show architecture', to_string=True)).group(1)
                # pos_1
            return self.archs[arch]
```

So I simply added a little code at `# pos_1` and everything works fine now!  ; ) ​