### PR TITLE
Fix incorrect jle condition codes

### DIFF
--- a/voltron/plugins/view/register.py
+++ b/voltron/plugins/view/register.py
@@ -684,10 +684,10 @@ class RegisterView (TerminalView):
                 else:
                     j = (True, 's!=o')
             elif inst in ['jle', 'jng']:
-                if values['z'] or values['s'] == values['o']:
-                    j = (True, 'z || s==o')
+                if values['z'] or values['s'] != values['o']:
+                    j = (True, 'z || s!=o')
                 else:
-                    j = (False, '!z && s!=o')
+                    j = (False, '!z && s==o')
             elif inst in ['jne', 'jnz']:
                 if not values['z']:
                     j = (True, '!z')


### PR DESCRIPTION
I was debugging a program and noticed that a jump was being made, but the jump indicator was indicating otherwise. I looked up the condition codes in the [Intel Architectures manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) and found that the correct condition codes for `jle`/`jng` should be ZF=1 or SF≠OF, but they were incorrectly set here. See Vol. 2A 3-547 or page 1143 of the combined PDF.