### PR TITLE
Handle alternative paths to bash.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Install Voltron for whichever debuggers are detected (only GDB and LLDB so
 # far).


### PR DESCRIPTION
Not all OSes put Bash in /bin/bash.