### PR TITLE
Allow overriding of GDB and LLDB paths.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,8 @@ END
     exit 1
 }
 
-GDB=$(command -v gdb)
-LLDB=$(command -v lldb)
+: ${GDB:=$(command -v gdb)}
+: ${LLDB:=$(command -v lldb)}
 APT_GET=$(command -v apt-get)
 YUM_YUM=$(command -v yum)
 YUM_DNF=$(command -v dnf)


### PR DESCRIPTION
If there are multiple versions of a debugger installed (e.g., lldb17 and lldb18), allow the user to specify which one we are installing for.