### PR TITLE
Remove unused dependency pysigset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,6 @@ requirements = [
     'requests',
     'requests_unixsocket',
     'six',
-    'pysigset',
     'pygments',
 ]
 if sys.platform == 'win32':


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the dependency `pysigset` is specified as a requirement in the `setup.py` file, when in reality it is not needed.

The dependency is unused since abf6ecd.

Hope this is helpful!

Best regards